### PR TITLE
Explicit relative imports for python3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-from coco_text import COCO_Text
-import coco_evaluation
+from .coco_text import COCO_Text
+from .coco_evaluation import *

--- a/coco_evaluation.py
+++ b/coco_evaluation.py
@@ -32,7 +32,7 @@ from copy import copy
 import editdistance
 import re
 
-from utils import *
+from .utils import *
 
 
 

--- a/coco_text.py
+++ b/coco_text.py
@@ -47,7 +47,7 @@ from matplotlib.collections import PatchCollection
 from matplotlib.patches import Rectangle, PathPatch
 from matplotlib.path import Path
 
-from utils import inter
+from .utils import inter
 
 
 


### PR DESCRIPTION
Python3 won't understand implicit relative imports: you either make it explicit (add a "." to look in the current folder) or use an absolute path